### PR TITLE
Sync parameters foreign keys

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2024-09-05
+- Se agrega soporte para llaves foraneas en las entidades sincronizables con eliminacion en cascada.
+- Se agrega nuevos metodos de SyncParameter para definir llaves foraneas.
+```php
+    SyncParameter::createUUIDForeignKey(string $name, int $version, string $linkedEntity);
+```
+```php
+    SyncParameter::createStringForeignKey(string $name, int $version, string $linkedEntity);
+```
+```php
+    SyncParameter::createIntForeignKey(string $name, int $version, string $linkedEntity);
+```
+
 ## 2024-09-01
 - Se corrige la comparacion de fechas de SyncedAt y ActionedAt en el repositorio de QueueActions.
 

--- a/src/Core/Entity/SyncParameter.php
+++ b/src/Core/Entity/SyncParameter.php
@@ -31,7 +31,8 @@ class SyncParameter
         public int               $version = 1,
         public bool              $isNullable = false,
         public array             $related = [],
-        public array             $options = []
+        public array             $options = [],
+        public ?string            $linkedEntity = null
     )
     {
         $this->validateRelated();
@@ -212,6 +213,45 @@ class SyncParameter
     public static function createRelationOneOfOne(array $relatedClass, int $version): self
     {
         return new SyncParameter("relations_one_of_one", SyncParameterType::RELATION_ONE_OF_ONE, $version, false, $relatedClass);
+    }
+
+    /**
+     * Creates a UUID foreign key parameter.
+     *
+     * @param string $name
+     * @param int $version
+     * @param string $linkedEntity
+     * @return self
+     */
+    public static function createUUIDForeignKey(string $name, int $version, string $linkedEntity): self
+    {
+        return new SyncParameter($name, SyncParameterType::UUID, $version, linkedEntity: $linkedEntity);
+    }
+
+    /**
+     * Creates a string foreign key parameter.
+     *
+     * @param string $name
+     * @param int $version
+     * @param string $linkedEntity
+     * @return self
+     */
+    public static function createStringForeignKey(string $name, int $version, string $linkedEntity): self
+    {
+        return new SyncParameter($name, SyncParameterType::STRING, $version, linkedEntity: $linkedEntity);
+    }
+
+    /**
+     * Creates an integer foreign key parameter.
+     *
+     * @param string $name
+     * @param int $version
+     * @param string $linkedEntity
+     * @return self
+     */
+    public static function createIntForeignKey(string $name, int $version, string $linkedEntity): self
+    {
+        return new SyncParameter($name, SyncParameterType::INT, $version, linkedEntity: $linkedEntity);
     }
 
     // ------------------------------------------------------------------------

--- a/src/Illuminate/Database/BaseSynchronizable.php
+++ b/src/Illuminate/Database/BaseSynchronizable.php
@@ -133,13 +133,18 @@ abstract class BaseSynchronizable extends Model implements IEntitySynchronizable
             $attribute["type"] = StringUtil::snakeCase($parameter->type->value);
             $attribute["nullable"] = $parameter->isNullable;
 
-            if($parameter->type == SyncParameterType::ENUM){
+            if ($parameter->linkedEntity !== null) {
+                $attribute["linked_entity"] = $parameter->linkedEntity;
+            }
+
+            if ($parameter->type == SyncParameterType::ENUM) {
                 $attribute["options"] = array_map(fn($item) => strval($item), $parameter->options);
             }
 
             if ($parameter->type == SyncParameterType::RELATION_ONE_OF_MANY || $parameter->type == SyncParameterType::RELATION_ONE_OF_ONE) {
                 $attribute["related"] = array_map(fn($classRelated) => $classRelated::schema(), $parameter->related);
             }
+
 
             $attributes[] = $attribute;
         }

--- a/tests/Feature/Api/GetMigrationSchemaApiTest.php
+++ b/tests/Feature/Api/GetMigrationSchemaApiTest.php
@@ -41,7 +41,8 @@ class GetMigrationSchemaApiTest extends ApiTestCase
         // Validate relations one of many
         $response->assertJsonPath("0.attributes.9.name", "relations_one_of_many");
         $response->assertJsonPath("0.attributes.9.related.0.entity", ChildFakeEntity::getEntityName());
-        $response->assertJsonPath("0.attributes.9.related.0.type", EntityType::EDITABLE->value);
+         $response->assertJsonPath("0.attributes.9.related.0.type", EntityType::EDITABLE->value);
+        $response->assertJsonPath("0.attributes.9.related.0.attributes.12.linked_entity",ParentFakeEntity::getEntityName());
 
         // Validate relations one of one
         $response->assertJsonPath("0.attributes.10.name", "relations_one_of_one");

--- a/tests/Unit/Repository/EloquentEntityRepositoryTest.php
+++ b/tests/Unit/Repository/EloquentEntityRepositoryTest.php
@@ -14,6 +14,7 @@ use AppTank\Horus\Illuminate\Database\EntitySynchronizable;
 use AppTank\Horus\Illuminate\Util\DateTimeUtil;
 use AppTank\Horus\Repository\EloquentEntityRepository;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
 use Tests\_Stubs\AdjacentFakeEntity;
 use Tests\_Stubs\AdjacentFakeEntityFactory;
 use Tests\_Stubs\ChildFakeEntity;
@@ -249,8 +250,9 @@ class EloquentEntityRepositoryTest extends TestCase
             deletedAtColumn: EntitySynchronizable::ATTR_SYNC_DELETED_AT);
     }
 
-    function testDeleteManyEntitiesIsSuccess()
+    function testSoftDeleteEntityParentAndSoftDeleteOnCascadeChildrenIsSuccess()
     {
+        Schema::enableForeignKeyConstraints();
         // Given
         $ownerId = $this->faker->uuid;
         /**

--- a/tests/_Stubs/AdjacentFakeEntity.php
+++ b/tests/_Stubs/AdjacentFakeEntity.php
@@ -17,7 +17,7 @@ class AdjacentFakeEntity extends EntitySynchronizable implements EntityDependsOn
     {
         return [
             SyncParameter::createString("name", 1),
-            SyncParameter::createUUID(self::FK_PARENT_ID, 1)
+            SyncParameter::createUUIDForeignKey(self::FK_PARENT_ID, 1, ParentFakeEntity::getEntityName())
         ];
     }
 

--- a/tests/_Stubs/ChildFakeEntity.php
+++ b/tests/_Stubs/ChildFakeEntity.php
@@ -49,7 +49,7 @@ class ChildFakeEntity extends EntitySynchronizable implements EntityDependsOn
             SyncParameter::createString(self::ATTR_STRING_VALUE, self::VERSION_ATTRIBUTES),
             SyncParameter::createBoolean(self::ATTR_BOOLEAN_VALUE, self::VERSION_ATTRIBUTES),
             SyncParameter::createTimestamp(self::ATTR_TIMESTAMP_VALUE, self::VERSION_ATTRIBUTES),
-            SyncParameter::createUUID(self::FK_PARENT_ID, self::VERSION_ATTRIBUTES)
+            SyncParameter::createUUIDForeignKey(self::FK_PARENT_ID, self::VERSION_ATTRIBUTES, ParentFakeEntity::getEntityName())
         ];
     }
 


### PR DESCRIPTION
- Se agrega soporte para llaves foraneas en las entidades sincronizables con eliminacion en cascada.
- Se agrega nuevos metodos de SyncParameter para definir llaves foraneas.
```php
    SyncParameter::createUUIDForeignKey(string $name, int $version, string $linkedEntity);
```
```php
    SyncParameter::createStringForeignKey(string $name, int $version, string $linkedEntity);
```
```php
    SyncParameter::createIntForeignKey(string $name, int $version, string $linkedEntity);
```