### PR TITLE
⭐ Feature: Entity Restrictions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.0
+- Added feature to add entity restrictions where it can define a max count of entities.
+- Fixed parse expiration days param in prune upload files command.
+
 ## v0.2.1
 - Fix deleting release in tag_release workflow.
 

--- a/readme.md
+++ b/readme.md
@@ -107,6 +107,8 @@ You can optionally
 * Whether UUIDs or Int will be used as the primary key.
 * Define a prefix for the tables of entities in the database.
 * Enable or disable the validation of access to entities. Improve performance by disabling this option.
+* Prefix for the tables of entities in the database.
+* Define the entity restrictions.
 
 ```php
 class AppServiceProvider extends ServiceProvider
@@ -126,7 +128,10 @@ class AppServiceProvider extends ServiceProvider
             validateAccess: true,
             connectionName: "sync_database",
             usesUUIDs: true,
-            prefixTables: 'hs'
+            prefixTables: 'hs',
+            entityRestrictions: [
+                new MaxCountEntityRestriction("entity_name", maxCount: 10)
+            ],
         );
        
          // Initialize Horus
@@ -261,7 +266,7 @@ Horus::getInstance()->setUserAuthenticated(
    [ // Array of Entities Granted
    new EntityGranted(
    "971785f7-0f01-46cd-a3ce-af9ce6273d3d", // User Owner Id
-   "animal", // Entity Name
+   "entity_name", // Entity Name
     "9135e859-b053-4cfb-b701-d5f240b0aab1", // Entity Id
     // Set the permissions for the entity
    , new AccessLevel(Permission::READ, Permission::CREATE)),
@@ -270,4 +275,21 @@ Horus::getInstance()->setUserAuthenticated(
    ]
  )
 );
+```
+
+### ⛔ Entity Restrictions
+
+If you want to apply a restriction to an entity, you can use the next restriction classes:
+
+* **MaxCountEntityRestriction**: Restricts the number of records that can be synchronized for an entity to specific user.
+
+
+#### Setup after initialization
+
+By default, the setup is set the Config class in the Horus initialization, but if you want to change the restrictions after you can use the next code:
+
+```php 
+Horus::getInstance()->setEntityRestrictions([
+    new MaxCountEntityRestriction("entity_name", maxCount: 10)
+]);
 ```

--- a/src/Application/Sync/SyncQueueActions.php
+++ b/src/Application/Sync/SyncQueueActions.php
@@ -282,7 +282,7 @@ class SyncQueueActions
         $userOwnerId = $this->userAuth->getEffectiveUserId();
         $currentCount = $this->entityRepository->getCount($userOwnerId, $entity);
 
-        if (($currentCount + $countToInsert) > $restriction->value) {
+        if (($currentCount + $countToInsert) > $restriction->maxCount) {
             throw new RestrictionException("Max count entity [$entity] restriction exceeded");
         }
     }

--- a/src/Core/Config/Config.php
+++ b/src/Core/Config/Config.php
@@ -21,6 +21,7 @@ class Config
 
     /** @var EntityRestriction[] */
     private array $entityRestrictions = [];
+    private array $restrictionsByEntity = [];
 
     /**
      * @param bool $validateAccess Indicates whether access validation is enabled.
@@ -45,6 +46,7 @@ class Config
         }
 
         $this->entityRestrictions = $entityRestrictions;
+        $this->populateRestrictionsByEntity();
     }
 
     /**
@@ -55,6 +57,7 @@ class Config
     function setEntityRestrictions(array $entityRestrictions): void
     {
         $this->entityRestrictions = $entityRestrictions;
+        $this->populateRestrictionsByEntity();
     }
 
     /**
@@ -77,5 +80,36 @@ class Config
         return $this->entityRestrictions;
     }
 
+    /**
+     * Checks if there are restrictions for a specific entity.
+     *
+     * @param string $entityName The name of the entity.
+     *
+     * @return bool True if there are restrictions; otherwise, false.
+     */
+    function hasRestrictions(string $entityName): bool
+    {
+        return isset($this->restrictionsByEntity[$entityName]);
+    }
 
+
+    /**
+     * Gets the restrictions for a specific entity.
+     * @param string $entityName
+     * @return EntityRestriction[]
+     */
+    function getRestrictionsByEntity(string $entityName): array
+    {
+        return $this->restrictionsByEntity[$entityName];
+    }
+
+    private function populateRestrictionsByEntity(): void
+    {
+        foreach ($this->entityRestrictions as $restriction) {
+            if (!isset($this->restrictionsByEntity[$restriction->getEntityName()])) {
+                $this->restrictionsByEntity[$restriction->getEntityName()] = [];
+            }
+            $this->restrictionsByEntity[$restriction->getEntityName()][] = $restriction;
+        }
+    }
 }

--- a/src/Core/Config/Config.php
+++ b/src/Core/Config/Config.php
@@ -2,6 +2,8 @@
 
 namespace AppTank\Horus\Core\Config;
 
+use AppTank\Horus\Core\Config\Restriction\EntityRestriction;
+
 /**
  * Class Config
  *
@@ -12,22 +14,27 @@ namespace AppTank\Horus\Core\Config;
  * @author John Ospina
  * Year: 2024
  */
-readonly class Config
+class Config
 {
 
-    public string $basePathFiles;
+    public readonly string $basePathFiles;
+
+    /** @var EntityRestriction[] */
+    private array $entityRestrictions = [];
 
     /**
      * @param bool $validateAccess Indicates whether access validation is enabled.
      * @param string|null $connectionName The name of the database connection, or null if not specified.
      * @param bool $usesUUIDs Indicates whether UUIDs are used as primary keys.
+     * @param EntityRestriction[] $entityRestrictions An array of entity restrictions.
      */
     function __construct(
-        public bool    $validateAccess = false,
-        public ?string $connectionName = null,
-        public bool    $usesUUIDs = false,
-        public ?string $prefixTables = "sync",
-        string         $basePathFiles = "horus/upload"
+        public readonly bool    $validateAccess = false,
+        public readonly ?string $connectionName = null,
+        public readonly bool    $usesUUIDs = false,
+        public readonly ?string $prefixTables = "sync",
+        string                  $basePathFiles = "horus/upload",
+        array                   $entityRestrictions = []
     )
     {
         // Validate if ends with a slash
@@ -36,8 +43,19 @@ readonly class Config
         } else {
             $this->basePathFiles = $basePathFiles;
         }
+
+        $this->entityRestrictions = $entityRestrictions;
     }
 
+    /**
+     * Sets the entity restrictions.
+     *
+     * @param EntityRestriction[] $entityRestrictions The entity restrictions.
+     */
+    function setEntityRestrictions(array $entityRestrictions): void
+    {
+        $this->entityRestrictions = $entityRestrictions;
+    }
 
     /**
      * Gets the path for the files that are pending to be uploaded.
@@ -47,6 +65,16 @@ readonly class Config
     function getPathFilesPending(): string
     {
         return $this->basePathFiles . "/pending";
+    }
+
+    /**
+     * Gets the entity restrictions.
+     *
+     * @return EntityRestriction[]
+     */
+    function getEntityRestrictions(): array
+    {
+        return $this->entityRestrictions;
     }
 
 

--- a/src/Core/Config/Restriction/EntityRestriction.php
+++ b/src/Core/Config/Restriction/EntityRestriction.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace AppTank\Horus\Core\Config\Restriction;
+
+/**
+ * Interface EntityRestriction
+ *
+ * Represents a restriction that can be applied to an entity.
+ *
+ * @package AppTank\Horus\Core\Config\Restriction
+ *
+ * @author John Ospina
+ * Year: 2024
+ */
+interface EntityRestriction
+{
+
+}

--- a/src/Core/Config/Restriction/EntityRestriction.php
+++ b/src/Core/Config/Restriction/EntityRestriction.php
@@ -14,5 +14,10 @@ namespace AppTank\Horus\Core\Config\Restriction;
  */
 interface EntityRestriction
 {
-
+    /**
+     * Retrieves the name of the entity associated with the restriction.
+     *
+     * @return string The name of the entity.
+     */
+    function getEntityName(): string;
 }

--- a/src/Core/Config/Restriction/MaxCountEntityRestriction.php
+++ b/src/Core/Config/Restriction/MaxCountEntityRestriction.php
@@ -16,7 +16,7 @@ readonly class MaxCountEntityRestriction implements EntityRestriction
 {
     public function __construct(
         public string $entityName,
-        public int    $value
+        public int $maxCount
     )
     {
 

--- a/src/Core/Config/Restriction/MaxCountEntityRestriction.php
+++ b/src/Core/Config/Restriction/MaxCountEntityRestriction.php
@@ -5,14 +5,14 @@ namespace AppTank\Horus\Core\Config\Restriction;
 /**
  * Interface EntityRestriction
  *
- * Represents a restriction that can be applied to an entity.
+ * Represents a restriction that can be applied to an entity indicating a limit on the number of entities that can be created.
  *
  * @package AppTank\Horus\Core\Config\Restriction
  *
  * @author John Ospina
  * Year: 2024
  */
-readonly class MaxEntityRestriction implements EntityRestriction
+readonly class MaxCountEntityRestriction implements EntityRestriction
 {
     public function __construct(
         public string $entityName,
@@ -20,5 +20,10 @@ readonly class MaxEntityRestriction implements EntityRestriction
     )
     {
 
+    }
+
+    function getEntityName(): string
+    {
+        return $this->entityName;
     }
 }

--- a/src/Core/Config/Restriction/MaxEntityRestriction.php
+++ b/src/Core/Config/Restriction/MaxEntityRestriction.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace AppTank\Horus\Core\Config\Restriction;
+
+/**
+ * Interface EntityRestriction
+ *
+ * Represents a restriction that can be applied to an entity.
+ *
+ * @package AppTank\Horus\Core\Config\Restriction
+ *
+ * @author John Ospina
+ * Year: 2024
+ */
+readonly class MaxEntityRestriction implements EntityRestriction
+{
+    public function __construct(
+        public string $entityName,
+        public int    $value
+    )
+    {
+
+    }
+}

--- a/src/Core/Exception/RestrictionException.php
+++ b/src/Core/Exception/RestrictionException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace AppTank\Horus\Core\Exception;
+
+class RestrictionException extends ClientException
+{
+    public function __construct(string $message = "Restriction exception")
+    {
+        parent::__construct($message);
+    }
+}

--- a/src/Core/Repository/EntityRepository.php
+++ b/src/Core/Repository/EntityRepository.php
@@ -3,6 +3,7 @@
 namespace AppTank\Horus\Core\Repository;
 
 use AppTank\Horus\Core\Entity\EntityReference;
+use AppTank\Horus\Core\Exception\ClientException;
 use AppTank\Horus\Core\Model\EntityData;
 use AppTank\Horus\Core\Model\EntityDelete;
 use AppTank\Horus\Core\Model\EntityInsert;
@@ -114,4 +115,14 @@ interface EntityRepository
      * @return EntitySynchronizable[] Returns an array with the entity hierarchy.
      */
     function getEntityPathHierarchy(EntityReference $entityRefChild): array;
+
+    /**
+     * Retrieves the count of entities associated with a specific user ID.
+     *
+     * @param string|int $userId The ID of the user whose entities are being counted.
+     *
+     * @return int The count of entities associated with the specified user ID.
+     * @throws ClientException
+     */
+    function getCount(string|int $userId, string $entityName): int;
 }

--- a/src/Horus.php
+++ b/src/Horus.php
@@ -135,7 +135,7 @@ class Horus
      */
     public function setEntityRestrictions(array $restrictions): void
     {
-        $this->config->setEntityRestrictions($restrictions);
+        self::getInstance()->config->setEntityRestrictions($restrictions);
     }
 
     /**

--- a/src/Horus.php
+++ b/src/Horus.php
@@ -4,6 +4,7 @@ namespace AppTank\Horus;
 
 use AppTank\Horus\Core\Auth\UserAuth;
 use AppTank\Horus\Core\Config\Config;
+use AppTank\Horus\Core\Config\Restriction\EntityRestriction;
 use AppTank\Horus\Core\EntityMap;
 use AppTank\Horus\Core\File\IFileHandler;
 use AppTank\Horus\Core\Mapper\EntityMapper;
@@ -124,6 +125,17 @@ class Horus
     {
         $this->userAuth = $userAuth;
         return $this;
+    }
+
+    /**
+     * Sets the restrictions for the container.
+     *
+     * @param EntityRestriction[] $restrictions Array of restrictions.
+     * @return void
+     */
+    public function setEntityRestrictions(array $restrictions): void
+    {
+        $this->config->setEntityRestrictions($restrictions);
     }
 
     /**

--- a/src/Illuminate/Console/PruneFilesUploadedCommand.php
+++ b/src/Illuminate/Console/PruneFilesUploadedCommand.php
@@ -79,7 +79,7 @@ class PruneFilesUploadedCommand extends Command
     public function handle()
     {
         try {
-            $expirationDays = $this->argument('expirationDays');
+            $expirationDays = intval($this->argument('expirationDays'));
             $this->deleteFilesPendingExpired($expirationDays);
             $this->deleteFilesReferencedInDataDeleted($expirationDays);
         } catch (\Exception $e) {

--- a/src/Illuminate/Http/Controller.php
+++ b/src/Illuminate/Http/Controller.php
@@ -35,7 +35,6 @@ abstract class Controller
             $this->validateUserActingAs();
             return $callback();
         } catch (ClientException $e) {
-            report($e);
             return $this->responseBadRequest($e->getMessage());
         } catch (\PDOException $e) {
             return $this->responseBadRequest($this->parseError($e->getMessage()));

--- a/src/Illuminate/Http/Controller/Data/PostSyncQueueActionsController.php
+++ b/src/Illuminate/Http/Controller/Data/PostSyncQueueActionsController.php
@@ -51,8 +51,7 @@ class PostSyncQueueActionsController extends Controller
         EntityAccessValidatorRepository $accessValidatorRepository,
         FileUploadedRepository          $fileUploadedRepository,
         IEventBus                       $eventBus,
-        EntityMapper                    $entityMapper,
-        Config                          $config
+        EntityMapper                    $entityMapper
     )
     {
         $this->useCase = new SyncQueueActions(
@@ -64,7 +63,7 @@ class PostSyncQueueActionsController extends Controller
             $eventBus,
             Horus::getInstance()->getFileHandler(),
             $entityMapper,
-            $config
+            Horus::getInstance()->getConfig()
         );
     }
 

--- a/src/Repository/EloquentEntityRepository.php
+++ b/src/Repository/EloquentEntityRepository.php
@@ -5,6 +5,7 @@ namespace AppTank\Horus\Repository;
 use AppTank\Horus\Core\Entity\EntityReference;
 use AppTank\Horus\Core\Entity\IEntitySynchronizable;
 use AppTank\Horus\Core\Entity\SyncParameter;
+use AppTank\Horus\Core\Exception\ClientException;
 use AppTank\Horus\Core\Exception\OperationNotPermittedException;
 use AppTank\Horus\Core\Hasher;
 use AppTank\Horus\Core\Mapper\EntityMapper;
@@ -425,6 +426,24 @@ readonly class EloquentEntityRepository implements EntityRepository
         return $entityHierarchy;
     }
 
+
+    /**
+     * Retrieves the count of entities associated with a specific user ID.
+     *
+     * @param string|int $userId The ID of the user whose entities are being counted.
+     *
+     * @return int The count of entities associated with the specified user ID.
+     * @throws ClientException
+     */
+    function getCount(int|string $userId, string $entityName): int
+    {
+        /**
+         * @var $entityClass EntitySynchronizable
+         */
+        $entityClass = $this->entityMapper->getEntityClass($entityName);
+        return $entityClass::query()->where(WritableEntitySynchronizable::ATTR_SYNC_OWNER_ID, $userId)->count();
+    }
+
     /**
      * Groups entity IDs by entity name from a list of operations.
      *
@@ -641,6 +660,5 @@ readonly class EloquentEntityRepository implements EntityRepository
 
         throw new OperationNotPermittedException("Operation not permitted for entity $entityClass");
     }
-
 
 }

--- a/tests/Unit/Repository/EloquentEntityRepositoryTest.php
+++ b/tests/Unit/Repository/EloquentEntityRepositoryTest.php
@@ -636,4 +636,17 @@ class EloquentEntityRepositoryTest extends TestCase
         $this->assertEquals($parentEntity->getId(), $result[0]->getId());
         $this->assertEquals($childEntity->getId(), $result[1]->getId());
     }
+
+    function testGetCountIsSuccess()
+    {
+        // Given
+        $userOwnerId = $this->faker->uuid;
+        $parentsEntities = $this->generateArray(fn() => ParentFakeEntityFactory::create($userOwnerId));
+
+        // When
+        $result = $this->entityRepository->getCount($userOwnerId, ParentFakeWritableEntity::getEntityName());
+
+        // Then
+        $this->assertEquals(count($parentsEntities), $result);
+    }
 }


### PR DESCRIPTION
### ⛔ Entity Restrictions

If you want to apply a restriction to an entity, you can use the next restriction classes:

* **MaxCountEntityRestriction**: Restricts the number of records that can be synchronized for an entity to specific user.


#### Setup after initialization

By default, the setup is set the Config class in the Horus initialization, but if you want to change the restrictions after you can use the next code:

```php 
Horus::getInstance()->setEntityRestrictions([
    new MaxCountEntityRestriction("entity_name", maxCount: 10)
]);
```