### PR TITLE
Added new parameter type to defines a custom type with own regex.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,6 @@
 # Changelog
+## v0.5.0
+- Added new parameter type to defines a custom type with own regex.
 
 ## v0.4.0
 - Added support to setup if a foreing entity is delete on cascade.

--- a/src/Core/Entity/SyncParameter.php
+++ b/src/Core/Entity/SyncParameter.php
@@ -26,6 +26,7 @@ class SyncParameter
      * @param array $options Additional options for the parameter (default is an empty array).
      * @param string|null $linkedEntity The name of the linked entity (default is null).
      * @param bool $deleteOnCascade Indicates if the parameter should be deleted on cascade (default is true).
+     * @param string|null $regex A regex pattern for validation. (Only for custom type)
      */
     public function __construct(
         public string            $name,
@@ -35,7 +36,8 @@ class SyncParameter
         public array             $related = [],
         public array             $options = [],
         public ?string           $linkedEntity = null,
-        public bool              $deleteOnCascade = true
+        public bool              $deleteOnCascade = true,
+        public ?string           $regex = null,
     )
     {
         $this->validateRelated();
@@ -192,6 +194,25 @@ class SyncParameter
     public static function createJSON(string $name, int $version, bool $isNullable = false): self
     {
         return new SyncParameter($name, SyncParameterType::JSON, $version, $isNullable);
+    }
+
+    /**
+     * Creates a custom parameter with a regex pattern.
+     *
+     * @param string $name The name of the parameter.
+     * @param string $regex The regex pattern for validation.
+     * @param int $version The version of the parameter.
+     * @param bool $isNullable Indicates if the parameter is nullable.
+     * @return self A new instance of SyncParameter.
+     */
+    public static function createCustom(string $name, string $regex, int $version, bool $isNullable = false): self
+    {
+        // Validate if the pattern regex is valid
+        if (@preg_match("/$regex/i", '') === false) {
+            throw new ClientException("Invalid regex pattern [$regex] for parameter [$name]");
+        }
+
+        return new SyncParameter($name, SyncParameterType::CUSTOM, $version, $isNullable, regex: $regex);
     }
 
     /**

--- a/src/Core/Entity/SyncParameterType.php
+++ b/src/Core/Entity/SyncParameterType.php
@@ -28,6 +28,7 @@ enum SyncParameterType: string
     case ENUM = "enum";
     case TIMESTAMP = "timestamp";
     case UUID = "uuid";
+    case CUSTOM = "custom";
 
     case REFERENCE_FILE = "ref_file";
 

--- a/src/Illuminate/Database/EntitySynchronizable.php
+++ b/src/Illuminate/Database/EntitySynchronizable.php
@@ -133,6 +133,10 @@ abstract class EntitySynchronizable extends Model implements IEntitySynchronizab
             $attribute["type"] = StringUtil::snakeCase($parameter->type->value);
             $attribute["nullable"] = $parameter->isNullable;
 
+            if ($parameter->type == SyncParameterType::CUSTOM) {
+                $attribute["regex"] = $parameter->regex;
+            }
+
             if ($parameter->linkedEntity !== null) {
                 $attribute["linked_entity"] = $parameter->linkedEntity;
                 $attribute["delete_on_cascade"] = $parameter->deleteOnCascade;

--- a/tests/Feature/Api/GetMigrationSchemaApiTest.php
+++ b/tests/Feature/Api/GetMigrationSchemaApiTest.php
@@ -34,7 +34,7 @@ class GetMigrationSchemaApiTest extends ApiTestCase
 
         $response->assertOk();
         $response->assertJsonStructure(self::JSON_SCHEMA);
-        $response->assertJson([ParentFakeWritableEntity::schema(),ReadableFakeEntity::schema()]);
+        $response->assertJson([ParentFakeWritableEntity::schema(), ReadableFakeEntity::schema()]);
         $response->assertJsonPath("0.type", EntityType::WRITABLE->value);
         $response->assertJsonPath("1.type", EntityType::READABLE->value);
 
@@ -42,12 +42,16 @@ class GetMigrationSchemaApiTest extends ApiTestCase
         $response->assertJsonPath("0.attributes.10.name", "relations_one_of_many");
         $response->assertJsonPath("0.attributes.10.related.0.entity", ChildFakeWritableEntity::getEntityName());
         $response->assertJsonPath("0.attributes.10.related.0.type", EntityType::WRITABLE->value);
-        $response->assertJsonPath("0.attributes.10.related.0.attributes.12.linked_entity",ParentFakeWritableEntity::getEntityName());
+        $response->assertJsonPath("0.attributes.10.related.0.attributes.12.linked_entity", ParentFakeWritableEntity::getEntityName());
         $response->assertJsonPath("0.attributes.10.related.0.attributes.12.delete_on_cascade", true);
 
         // Validate relations one of one
-        $response->assertJsonPath("0.attributes.11.name", "relations_one_of_one");
-        $response->assertJsonPath("0.attributes.11.related.0.entity", AdjacentFakeWritableEntity::getEntityName());
+        $response->assertJsonPath("0.attributes.13.name", ParentFakeWritableEntity::ATTR_CUSTOM);
+        $response->assertJsonPath("0.attributes.13.regex", ParentFakeWritableEntity::REGEX_CUSTOM);
+
+        // Validate custom
+        $response->assertJsonPath("0.attributes.13.name", ParentFakeWritableEntity::ATTR_CUSTOM);
+
 
         foreach ($response->json()[0]["attributes"] as $attribute) {
             if ($attribute["name"] == WritableEntitySynchronizable::ATTR_SYNC_DELETED_AT) {

--- a/tests/_Stubs/ParentFakeWritableEntity.php
+++ b/tests/_Stubs/ParentFakeWritableEntity.php
@@ -21,11 +21,15 @@ class ParentFakeWritableEntity extends WritableEntitySynchronizable
 
     const string ATTR_IMAGE = "image";
 
+    const string ATTR_CUSTOM = "custom";
+
     const int VERSION_DEFAULT = 1;
 
     const int VERSION_CHILDREN = 2;
 
     const array ENUM_VALUES = ["value1", "value2", "value3"];
+
+    const string REGEX_CUSTOM = "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$";
 
     public static function parameters(): array
     {
@@ -37,7 +41,8 @@ class ParentFakeWritableEntity extends WritableEntitySynchronizable
             SyncParameter::createEnum(self::ATTR_ENUM, self::ENUM_VALUES, self::VERSION_DEFAULT),
             SyncParameter::createRelationOneOfMany([ChildFakeWritableEntity::class], self::VERSION_CHILDREN),
             SyncParameter::createRelationOneOfOne([AdjacentFakeWritableEntity::class], self::VERSION_CHILDREN),
-            SyncParameter::createReferenceFile(self::ATTR_IMAGE, self::VERSION_DEFAULT, true)
+            SyncParameter::createReferenceFile(self::ATTR_IMAGE, self::VERSION_DEFAULT, true),
+            SyncParameter::createCustom(self::ATTR_CUSTOM, self::REGEX_CUSTOM, self::VERSION_DEFAULT, true),
         ];
     }
 


### PR DESCRIPTION
### Description

This pull request introduces support for a new custom parameter type with regex validation, updates the migration process to handle this new type, and adds corresponding tests and documentation updates. The most important changes are grouped below by theme.

### Support for Custom Parameter Type:
* Added a new `CUSTOM` parameter type to the `SyncParameterType` enum. (`src/Core/Entity/SyncParameterType.php`)
* Updated the `SyncParameter` class to include a `regex` property and a static `createCustom` method for creating custom parameters with regex validation. (`src/Core/Entity/SyncParameter.php`) [[1]](diffhunk://#diff-d209f2486b2c205351e53608517d6899e84ed89e4d2b107bbaed9fb5cad784e3R29) [[2]](diffhunk://#diff-d209f2486b2c205351e53608517d6899e84ed89e4d2b107bbaed9fb5cad784e3L38-R40) [[3]](diffhunk://#diff-d209f2486b2c205351e53608517d6899e84ed89e4d2b107bbaed9fb5cad784e3R199-R217)

### Migration Enhancements:
* Modified the `createColumn` method to handle the `CUSTOM` parameter type and throw an exception for unsupported types. (`database/migrations/2024_06_05_00002_create_sync_entities.php`)
* Added a new `applyCustomConstraints` method to add regex-based constraints for PostgreSQL when handling custom parameters. (`database/migrations/2024_06_05_00002_create_sync_entities.php`)

### Testing and Validation:
* Added a test case to validate the schema and ensure the custom parameter type is correctly handled, including regex validation. (`tests/Feature/Api/GetMigrationSchemaApiTest.php`)
* Updated the `ParentFakeWritableEntity` stub to include a custom parameter with a regex pattern for testing. (`tests/_Stubs/ParentFakeWritableEntity.php`) [[1]](diffhunk://#diff-c796f8cead7cdd88ea6d9f84361e996e6a7e8f36fd14f02ee1eeef94e98cd4e3R24-R33) [[2]](diffhunk://#diff-c796f8cead7cdd88ea6d9f84361e996e6a7e8f36fd14f02ee1eeef94e98cd4e3L40-R45)

### Documentation and Schema Updates:
* Updated the changelog to document the addition of the custom parameter type. (`changelog.md`)
* Enhanced the `schema` method in `EntitySynchronizable` to include the `regex` attribute for custom parameters. (`src/Illuminate/Database/EntitySynchronizable.php`)

### Restrictions
* Only apply to postgress.